### PR TITLE
🧪 Add tests for formatTime utility and fix existing tests

### DIFF
--- a/src/lib/formatTime.test.ts
+++ b/src/lib/formatTime.test.ts
@@ -1,0 +1,24 @@
+import { expect, test, mock } from "bun:test";
+
+// Mock dependencies of utils.ts to allow importing formatTime
+mock.module("clsx", () => ({
+  clsx: () => "",
+}));
+
+mock.module("tailwind-merge", () => ({
+  twMerge: () => "",
+}));
+
+test("formatTime correctly formats seconds to mm:ss", async () => {
+  const { formatTime } = await import("./utils");
+
+  expect(formatTime(0)).toBe("00:00");
+  expect(formatTime(5)).toBe("00:05");
+  expect(formatTime(59)).toBe("00:59");
+  expect(formatTime(60)).toBe("01:00");
+  expect(formatTime(75)).toBe("01:15");
+  expect(formatTime(600)).toBe("10:00");
+  expect(formatTime(3599)).toBe("59:59");
+  expect(formatTime(3600)).toBe("60:00");
+  expect(formatTime(3661)).toBe("61:01");
+});

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -12,7 +12,7 @@ mock.module("clsx", () => ({
       } else if (Array.isArray(input)) {
         input.forEach(process);
       } else if (typeof input === "object") {
-        Object.entries(input).forEach(([key, value]) => {
+        Object.entries(input as Record<string, unknown>).forEach(([key, value]) => {
           if (value) result.push(key);
         });
       }
@@ -43,17 +43,10 @@ mock.module("tailwind-merge", () => ({
   },
 }));
 
-// Re-implementing cn to avoid the "Cannot find package 'clsx'" error that
-// occurs during import when node_modules is missing.
-// This matches the production logic exactly.
-import { clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+test("cn utility function tests", async () => {
+  // Use dynamic import to ensure mocks are active and handle missing node_modules
+  const { cn } = await import("./utils");
 
-function cn(...inputs: unknown[]) {
-  return twMerge(clsx(inputs));
-}
-
-test("cn utility function tests", () => {
   expect(cn("base", "extra")).toContain("base");
   expect(cn("base", "extra")).toContain("extra");
 


### PR DESCRIPTION
Added comprehensive unit tests for the `formatTime` utility function in `src/lib/utils.ts`. 

The new test suite covers:
- Zero seconds formatting (`00:00`)
- Single-digit seconds (`00:05`)
- Minutes boundary cases (`01:00`, `10:00`)
- Large number of seconds (`59:59`, `60:00`, `61:01`)

Additionally, I refactored the existing `src/lib/utils.test.ts` to:
1. Fix a TypeScript error in the mock implementation.
2. Use dynamic `await import()` for the module under test, allowing `bun test` to correctly intercept dependencies with `mock.module` even when physical `node_modules` are absent in the environment.
3. Test the actual source implementation of the `cn` function instead of a local duplicate.

---
*PR created automatically by Jules for task [10562802825687823536](https://jules.google.com/task/10562802825687823536) started by @PaddySeahorse*