### PR TITLE
Fix mobile layout overflow (Issue #21)

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -72,15 +72,15 @@ export default function Pomodoro({ params }: { params: Promise<{ locale: string 
 
       {!timer.isFullscreen && (
         <div className="relative z-10 container mx-auto px-4 py-8">
-          <header className="mb-8 flex items-center justify-between">
-            <div className="flex-1 text-center">
-              <h1 className={`mb-2 text-4xl font-bold ${theme === 'dark' ? 'text-white' : 'text-gray-800'}`}>
+          <header className="mb-8 flex items-center justify-between gap-4">
+            <div className="flex-1 text-center sm:text-left">
+              <h1 className={`mb-2 text-3xl sm:text-4xl font-bold ${theme === 'dark' ? 'text-white' : 'text-gray-800'}`}>
                 {tPage('title')}
               </h1>
               <p className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>{tPage('subtitle')}</p>
             </div>
 
-            <div className="flex gap-3">
+            <div className="flex gap-2 sm:gap-3">
               <button
                 onClick={() => {
                   startTransition(() => {
@@ -107,13 +107,13 @@ export default function Pomodoro({ params }: { params: Promise<{ locale: string 
           </header>
 
           <div className="mx-auto grid max-w-4xl gap-8 lg:grid-cols-2">
-            <div className="rounded-3xl border border-white/30 bg-white/70 p-8 shadow-2xl backdrop-blur-lg">
-              <div className="mb-8 flex justify-center gap-3">
+            <div className="rounded-3xl border border-white/30 bg-white/70 p-4 sm:p-8 shadow-2xl backdrop-blur-lg">
+              <div className="mb-8 flex flex-wrap justify-center gap-2 sm:gap-3">
                 {TIMER_STATES.map(({ key }) => (
                   <button
                     key={key}
                     onClick={() => timer.switchState(key)}
-                    className={`rounded-full px-6 py-3 font-semibold transition-all duration-300 ${
+                    className={`rounded-full px-4 py-2 sm:px-6 sm:py-3 text-sm sm:text-base font-semibold transition-all duration-300 ${
                       timer.state === key ? 'scale-105 shadow-lg' : 'bg-white/50 hover:bg-white/80'
                     }`}
                     style={{

--- a/src/components/timer/TimerControls.tsx
+++ b/src/components/timer/TimerControls.tsx
@@ -25,14 +25,14 @@ export function TimerControls({
 }: TimerControlsProps) {
   const t = useTranslations('Timer');
   return (
-    <div className={cn('flex justify-center gap-4', fullscreen && 'gap-6')}>
+    <div className={cn('flex flex-wrap justify-center gap-2 sm:gap-4', fullscreen && 'gap-4 sm:gap-6')}>
       <button
         onClick={onToggle}
         className={cn(
-          'flex items-center gap-3 rounded-full text-white font-semibold transition-all duration-300 active:scale-95',
+          'flex items-center gap-2 sm:gap-3 rounded-full text-white font-semibold transition-all duration-300 active:scale-95',
           fullscreen
-            ? 'px-12 py-6 text-2xl shadow-2xl hover:scale-105'
-            : 'px-10 py-4 text-lg shadow-lg hover:scale-105 hover:shadow-xl'
+            ? 'px-8 py-4 sm:px-12 sm:py-6 text-xl sm:text-2xl shadow-2xl hover:scale-105'
+            : 'px-6 py-3 sm:px-10 sm:py-4 text-base sm:text-lg shadow-lg hover:scale-105 hover:shadow-xl'
         )}
         style={{ backgroundColor: color }}
       >
@@ -41,7 +41,7 @@ export function TimerControls({
       {fullscreen && onStop ? (
         <button
           onClick={onStop}
-          className="flex items-center gap-3 rounded-full bg-gray-200 px-10 py-6 text-2xl font-semibold text-gray-700 transition-all duration-300 hover:bg-gray-300 active:scale-95"
+          className="flex items-center gap-2 sm:gap-3 rounded-full bg-gray-200 px-8 py-4 sm:px-10 sm:py-6 text-xl sm:text-2xl font-semibold text-gray-700 transition-all duration-300 hover:bg-gray-300 active:scale-95"
         >
           <Square />
           {t('stop')}
@@ -50,7 +50,7 @@ export function TimerControls({
         <button
           onClick={onReset}
           className={cn(
-            'flex items-center gap-3 rounded-full px-8 py-4 text-lg font-semibold transition-all duration-300 hover:scale-105 active:scale-95',
+            'flex items-center gap-2 sm:gap-3 rounded-full px-6 py-3 sm:px-8 sm:py-4 text-base sm:text-lg font-semibold transition-all duration-300 hover:scale-105 active:scale-95',
             theme === 'dark' ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
           )}
         >


### PR DESCRIPTION
The layout on mobile screens had issues where the padding was too large and the components on the side would get clipped off the edge of the viewport. This update tweaks the UI layout grid so that child components adapt using flex-wrap and responsive sizes. Smaller paddings and icon gaps were added using tailwind's `sm:` modifier.

Changes:
- In `page.tsx`: Reduced container p-8 to `p-4 sm:p-8`, making sure the card doesn't exceed screen boundaries on mobile. Updated `flex-1 text-center` to `sm:text-left` and adjusted header size/wrapping.
- In `TimerControls.tsx`: Allowed flex-wrap on control actions, reduced inner padding of buttons on smaller screens, adjusting `px-10 py-4 text-lg` to `px-6 py-3 sm:px-10 sm:py-4 text-base sm:text-lg`.

---
*PR created automatically by Jules for task [3862011831648642364](https://jules.google.com/task/3862011831648642364) started by @PaddySeahorse*