### PR TITLE
Make sidebar menu skeleton width dynamic

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -602,13 +602,12 @@ function SidebarMenuBadge({
 function SidebarMenuSkeleton({
   className,
   showIcon = false,
+  width = '70%',
   ...props
 }: React.ComponentProps<'div'> & {
   showIcon?: boolean;
+  width?: string | number;
 }) {
-  // Fixed width for skeleton loading
-  const width = '70%';
-
   return (
     <div
       data-slot="sidebar-menu-skeleton"


### PR DESCRIPTION
The `SidebarMenuSkeleton` component in `src/components/ui/sidebar.tsx` previously had a hardcoded width of '70%' for its text skeleton. This change introduces a `width` prop, allowing for more flexible skeleton loading layouts. The prop defaults to '70%' and supports both string and number values.

---
*PR created automatically by Jules for task [11508738048973665685](https://jules.google.com/task/11508738048973665685) started by @PaddySeahorse*