### PR TITLE
feat: Add local storage persistence

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -13,6 +13,7 @@ import { FullscreenTimer } from '@/components/timer/FullscreenTimer';
 import { TimerControls } from '@/components/timer/TimerControls';
 import { TimerDisplay } from '@/components/timer/TimerDisplay';
 import { ToastSystem } from '@/components/ui/ToastSystem';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useTasks } from '@/hooks/useTasks';
 import { useTimer } from '@/hooks/useTimer';
 import { useToasts } from '@/hooks/useToasts';
@@ -28,7 +29,7 @@ import { use } from 'react';
 
 export default function Pomodoro({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = use(params);
-  const [theme, setTheme] = useState<ThemeMode>('light');
+  const [theme, setTheme] = useLocalStorage<ThemeMode>('pomodoro-theme', 'light');
   const { toasts, addToast } = useToasts();
   const tPage = useTranslations('Page');
   const tTimer = useTranslations('Timer');

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(initialValue);
+
+  // Effect to read from local storage after mount to avoid hydration mismatch
+  useEffect(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      if (item) {
+        setStoredValue(JSON.parse(item));
+      }
+    } catch (error) {
+      console.warn(`Error reading localStorage key "${key}":`, error);
+    }
+  }, [key]);
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = useCallback((value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      setStoredValue((prevValue) => {
+        const valueToStore = value instanceof Function ? value(prevValue) : value;
+        // Save to local storage
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem(key, JSON.stringify(valueToStore));
+        }
+        return valueToStore;
+      });
+    } catch (error) {
+      console.warn(`Error setting localStorage key "${key}":`, error);
+    }
+  }, [key]);
+
+  return [storedValue, setValue] as const;
+}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import type { Task } from '@/lib/types';
+import { useLocalStorage } from './useLocalStorage';
 
 interface TaskDraft {
   text: string;
@@ -15,7 +16,7 @@ const initialDraft: TaskDraft = {
 };
 
 export function useTasks() {
-  const [tasks, setTasks] = useState<Task[]>([]);
+  const [tasks, setTasks] = useLocalStorage<Task[]>('pomodoro-tasks', []);
   const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);
   const [showTaskInput, setShowTaskInput] = useState(false);
   const [taskDraft, setTaskDraft] = useState<TaskDraft>(initialDraft);

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { TimerConfig, TimerState } from '@/lib/types';
+import { useLocalStorage } from './useLocalStorage';
 
 const FOCUS_MINUTES_MIN = 15;
 const FOCUS_MINUTES_MAX = 120;
@@ -21,7 +22,7 @@ interface UseTimerOptions {
 
 export function useTimer({ onComplete }: UseTimerOptions = {}) {
   const [state, setState] = useState<TimerState>('focus');
-  const [customTime, setCustomTime] = useState(25);
+  const [customTime, setCustomTime] = useLocalStorage('pomodoro-custom-time', 25);
   const [timeLeft, setTimeLeft] = useState(25 * 60);
   const [totalTime, setTotalTime] = useState(25 * 60);
   const [isRunning, setIsRunning] = useState(false);


### PR DESCRIPTION
This PR introduces local storage persistence to retain user states such as tasks, timer settings, and theme preferences across sessions. A custom `useLocalStorage` hook was created to ensure hydration safety in Next.js.

---
*PR created automatically by Jules for task [9589712962579148550](https://jules.google.com/task/9589712962579148550) started by @PaddySeahorse*