### PR TITLE
refactor(lib): remove unused ClassValue import in utils.ts

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
-import { clsx, type ClassValue } from 'clsx';
+import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: Parameters<typeof clsx>) {
   return twMerge(clsx(inputs));
 }
 


### PR DESCRIPTION
Use Parameters<typeof clsx> in the cn function signature to maintain type safety without requiring an explicit ClassValue import.